### PR TITLE
Fixed Russian language name in navbar

### DIFF
--- a/koroonakaart/src/components/Navbar.vue
+++ b/koroonakaart/src/components/Navbar.vue
@@ -59,7 +59,7 @@ export default {
 
   data() {
     return {
-      languageNames: ["Eesti", "English", "Pусский"],
+      languageNames: ["Eesti", "English", "Русский"],
       updatedOn: data.updatedOn
     };
   },


### PR DESCRIPTION
Very minor change, I know, but it bothered me.

Previously, upper-case latin "p" was used instead of an upper-case cyrillic "r". Not only does it look weird, it can cause issues with accessibility software such as screen readers.

Additionally, I would suggest considering changing the font-family used on the website to prefer a pan-unicode (or at least supporting Estonian diacritics and Cyrillics) instead of Avenir. Free and popular options include Roboto or Open Sans. Currently the russian version of the website has jarring differences in font weight between cyrillic and latin texts.