### PR TITLE
Fixed image exports for graphs with custom buttons

### DIFF
--- a/koroonakaart/src/components/Map.vue
+++ b/koroonakaart/src/components/Map.vue
@@ -28,6 +28,7 @@ export default {
           height: 470,
           events: {
             load: function() {
+              if(!this.exportSVGElements) return;
               // Buttons have indexes go in even numbers (button1 [0], button2 [2])
               // Odd indexes are button symbols
               const button = this.exportSVGElements[4];
@@ -40,6 +41,7 @@ export default {
               button.setState(2);
             },
             redraw: function() {
+              if(!this.exportSVGElements) return;
               // Redraw seems to be async so setTimeout for the button to update state
               setTimeout(() => {
                 this.exportSVGElements[4].setState(

--- a/koroonakaart/src/components/charts/CumulativeCasesChart.vue
+++ b/koroonakaart/src/components/charts/CumulativeCasesChart.vue
@@ -21,6 +21,8 @@ export default {
             load: function() {
               // Buttons have indexes go in even numbers (button1 [0], button2 [2])
               // Odd indexes are button symbols
+              if (!this.exportSVGElements) return
+
               const button = this.exportSVGElements[4];
 
               // States:
@@ -33,6 +35,8 @@ export default {
             redraw: function() {
               // Redraw seems to be async so setTimeout for the button to update state
               setTimeout(() => {
+                if (!this.exportSVGElements) return;
+
                 this.exportSVGElements[4].setState(
                   this.options.chartType === "linear" ? 2 : 0
                 );

--- a/koroonakaart/src/components/charts/CumulativeTestsChart.vue
+++ b/koroonakaart/src/components/charts/CumulativeTestsChart.vue
@@ -25,6 +25,7 @@ export default {
           height: 470,
           events: {
             load: function() {
+              if(!this.exportSVGElements) return;
               // Buttons have indexes go in even numbers (button1 [0], button2 [2])
               // Odd indexes are button symbols
               const button = this.exportSVGElements[4];
@@ -37,6 +38,7 @@ export default {
               button.setState(2);
             },
             redraw: function() {
+              if(!this.exportSVGElements) return;
               // Redraw seems to be async so setTimeout for the button to update state
               setTimeout(() => {
                 this.exportSVGElements[4].setState(

--- a/koroonakaart/src/components/charts/DailyCountyCasesChart.vue
+++ b/koroonakaart/src/components/charts/DailyCountyCasesChart.vue
@@ -25,6 +25,7 @@ export default {
           height: 470,
           events: {
             load: function() {
+              if(!this.exportSVGElements) return;
               // Buttons have indexes go in even numbers (button1 [0], button2 [2])
               // Odd indexes are button symbols
               const button = this.exportSVGElements[4];
@@ -37,6 +38,7 @@ export default {
               button.setState(2);
             },
             redraw: function() {
+              if(!this.exportSVGElements) return;
               // Redraw seems to be async so setTimeout for the button to update state
               setTimeout(() => {
                 this.exportSVGElements[4].setState(

--- a/koroonakaart/src/components/charts/PositiveNegativeChart.vue
+++ b/koroonakaart/src/components/charts/PositiveNegativeChart.vue
@@ -26,6 +26,7 @@ export default {
           height: 470,
           events: {
             load: function() {
+              if(!this.exportSVGElements) return;
               // Buttons have indexes go in even numbers (button1 [0], button2 [2])
               // Odd indexes are button symbols
               const button = this.exportSVGElements[4];
@@ -38,6 +39,7 @@ export default {
               button.setState(2);
             },
             redraw: function() {
+              if(!this.exportSVGElements) return;
               // Redraw seems to be async so setTimeout for the button to update state
               setTimeout(() => {
                 this.exportSVGElements[4].setState(

--- a/koroonakaart/src/components/charts/PositiveTestsAgeDistributionChart.vue
+++ b/koroonakaart/src/components/charts/PositiveTestsAgeDistributionChart.vue
@@ -26,6 +26,7 @@ export default {
           height: 470,
           events: {
             load: function() {
+              if(!this.exportSVGElements) return;
               // Buttons have indexes go in even numbers (button1 [0], button2 [2])
               // Odd indexes are button symbols
               const button = this.exportSVGElements[2];
@@ -38,6 +39,7 @@ export default {
               button.setState(2);
             },
             redraw: function() {
+              if(!this.exportSVGElements) return;
               // Redraw seems to be async so setTimeout for the button to update state
               setTimeout(() => {
                 this.exportSVGElements[4].setState(


### PR DESCRIPTION
  "TypeError: this.exportSVGElements is undefined" was thrown when
  trying to export image from graphs with custom buttons. Checking if
  the method exists before hand and if not then returning should fix
  this.