### PR TITLE
Move chart title up in charts to prevent overlap.

### DIFF
--- a/koroonakaart/src/components/charts/ConfirmedCasesByCountiesChart.vue
+++ b/koroonakaart/src/components/charts/ConfirmedCasesByCountiesChart.vue
@@ -16,7 +16,7 @@ export default {
         title: {
           text: this.$t("confirmedCasesByCounties"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         navigation: {

--- a/koroonakaart/src/components/charts/CumulativeCasesChart.vue
+++ b/koroonakaart/src/components/charts/CumulativeCasesChart.vue
@@ -51,7 +51,7 @@ export default {
         title: {
           text: this.$t("cumulativeCases"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         exporting: {

--- a/koroonakaart/src/components/charts/CumulativeTestsChart.vue
+++ b/koroonakaart/src/components/charts/CumulativeTestsChart.vue
@@ -16,7 +16,7 @@ export default {
         title: {
           text: this.$t("cumulativeTests"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         chartType: "linear",

--- a/koroonakaart/src/components/charts/DailyCountyCasesChart.vue
+++ b/koroonakaart/src/components/charts/DailyCountyCasesChart.vue
@@ -18,7 +18,7 @@ export default {
         title: {
           text: this.$t("confirmedCasesByCounties"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         chart: {

--- a/koroonakaart/src/components/charts/NewCasesPerDayChart.vue
+++ b/koroonakaart/src/components/charts/NewCasesPerDayChart.vue
@@ -16,7 +16,7 @@ export default {
         title: {
           text: this.$t("newCasesPerDay"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         chart: {

--- a/koroonakaart/src/components/charts/PositiveNegativeChart.vue
+++ b/koroonakaart/src/components/charts/PositiveNegativeChart.vue
@@ -18,7 +18,7 @@ export default {
         title: {
           text: this.$t("positiveNegativeTitle"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         chart: {

--- a/koroonakaart/src/components/charts/PositiveTestsAgeDistributionChart.vue
+++ b/koroonakaart/src/components/charts/PositiveTestsAgeDistributionChart.vue
@@ -18,7 +18,7 @@ export default {
         title: {
           text: this.$t("distributionOfPositiveTests"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         chart: {

--- a/koroonakaart/src/components/charts/TestsAgeSexDistributionChart.vue
+++ b/koroonakaart/src/components/charts/TestsAgeSexDistributionChart.vue
@@ -16,7 +16,7 @@ export default {
         title: {
           text: this.$t("distributionOfAgeSexTests"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         chart: {

--- a/koroonakaart/src/components/charts/TestsPerDayChart.vue
+++ b/koroonakaart/src/components/charts/TestsPerDayChart.vue
@@ -16,7 +16,7 @@ export default {
         title: {
           text: this.$t("testsPerDay"),
           align: "left",
-          y: 30
+          y: 25
         },
 
         chart: {

--- a/koroonakaart/src/components/charts/TestsPopRatioChart.vue
+++ b/koroonakaart/src/components/charts/TestsPopRatioChart.vue
@@ -16,7 +16,7 @@ export default {
         title: {
           text: this.$t("testsPer10000"),
           align: "left",
-          y: 30
+          y: 25
         },
         navigation: {
           buttonOptions: {


### PR DESCRIPTION
Several titles overlap the chart Y-values. As seen below.

![image](https://user-images.githubusercontent.com/23059874/78123531-f5ca4d80-7416-11ea-8acb-2577f649024c.png)

Moved the chart titles up a bit (decreased Y values).

![image](https://user-images.githubusercontent.com/23059874/78126258-f06f0200-741a-11ea-9bd4-c5220510a80c.png)

(Edit: Moving up too much would mess up mobile view)
