### PR TITLE
Remove Linear and Logarithmic buttons from 14-day cumulative cases chart.

### DIFF
--- a/koroonakaart/src/components/charts/CumulativeCasesPer100kChart.vue
+++ b/koroonakaart/src/components/charts/CumulativeCasesPer100kChart.vue
@@ -26,36 +26,7 @@ export default {
 
         chart: {
           height: this.height,
-          width: this.width,
-          events: {
-            load: function() {
-              // Buttons have indexes go in even numbers (button1 [0], button2 [2])
-              // Odd indexes are button symbols
-              if (!this.exportSVGElements) return;
-
-              const button = this.exportSVGElements[4];
-
-              // States:
-              // 0 - normal
-              // 1 - hover
-              // 2 - selected
-              // 3 - disabled
-              button.setState(2);
-            },
-            redraw: function() {
-              // Redraw seems to be async so setTimeout for the button to update state
-              setTimeout(() => {
-                if (!this.exportSVGElements) return;
-
-                this.exportSVGElements[4].setState(
-                  this.options.chartType === "linear" ? 2 : 0
-                );
-                this.exportSVGElements[2].setState(
-                  this.options.chartType === "logarithmic" ? 2 : 0
-                );
-              }, 100);
-            }
-          }
+          width: this.width
         },
 
         title: {
@@ -90,27 +61,6 @@ export default {
                 "separator",
                 "embed"
               ]
-            },
-
-            customButton2: {
-              text: this.$t("logarithmic"),
-              onclick: function() {
-                this.options.chartType = "logarithmic";
-
-                this.yAxis[0].update({
-                  type: "logarithmic"
-                });
-              }
-            },
-            customButton: {
-              text: this.$t("linear"),
-              onclick: function() {
-                this.options.chartType = "linear";
-
-                this.yAxis[0].update({
-                  type: "linear"
-                });
-              }
             }
           }
         },
@@ -241,10 +191,6 @@ export default {
       this.chartOptions.title.text = this.$t("cumulativeCasesPer100k");
       this.chartOptions.yAxis.title.text = this.$t("numberOfCases");
       this.chartOptions.series[0].name = this.$t("active100k");
-      this.chartOptions.exporting.buttons.customButton.text = this.$t("linear");
-      this.chartOptions.exporting.buttons.customButton2.text = this.$t(
-        "logarithmic"
-      );
     }
   }
 };


### PR DESCRIPTION
I discovered that title for 14-day cumulative cases chart is overlapping with linear and logarithmic for this chart in mobile.
![image](https://user-images.githubusercontent.com/21247241/92331357-aef41a00-f07e-11ea-9eff-01bfe7933359.png)

So I figured that maybe we can just remove these buttons for this chart? There might be some other fixes for this problem, but I couldn't figure anything else out.