### PR TITLE
Add Github actions (CI) support + Docker support

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,74 @@
+name: Build artifacts
+
+# this action will be run only manually (only visible on master branch)
+# go to "Actions" and click "Run workflow" button at right side of screen
+on: [workflow_dispatch]
+#on: [push]
+
+jobs:
+  fetch_data:
+    name: Fetch data
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          cd TEHIK_Open_Data_Loading_Scripts/
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Fetch data from TEHIK and aggregating it as data.json
+        run: |
+          cd TEHIK_Open_Data_Loading_Scripts/
+          python main.py
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: data.json
+          path: koroonakaart/src/data.json
+          retention-days: 7
+
+  build_frontend:
+    name: Build frontend
+    needs: fetch_data
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download data.json from data fetching job
+        uses: actions/download-artifact@v2
+        with:
+          name: data.json
+
+      - shell: bash
+        run: cp data.json koroonakaart/src/data.json
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Build frontend
+        run: |
+          cd koroonakaart
+          npm install
+          npm run build
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: frontend with data
+          path: |
+            koroonakaart/dist/
+          retention-days: 7
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.idea/
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+.directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN cd koroonakaart \
 #########################
 # STEP 3 build the image (Nginx serving frontend)
 #########################
+# https://hub.docker.com/_/nginx
 FROM nginx:1.19.2-alpine
 
+# Nginx needs to redirect requests like '/et' etc to index.html
+RUN sed -i '/index.html index.htm;/ i try_files $uri /index.html;' /etc/nginx/conf.d/default.conf
+
 COPY --from=build_frontend /app/koroonakaart/dist /usr/share/nginx/html
+COPY --from=fetch_data /app/koroonakaart/src/data.json /usr/share/nginx/html/data.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+############################
+# STEP 1 fetch data from TEHIK and aggregate it to into data.json
+############################
+# https://hub.docker.com/_/python
+FROM python:3.7-buster AS fetch_data
+
+WORKDIR /app
+COPY . .
+RUN cd TEHIK_Open_Data_Loading_Scripts \
+    python -m pip install --upgrade pip \
+    python main.py
+
+#########################
+# STEP 2 build frontend
+#########################
+# https://hub.docker.com/_/node
+FROM node:erbium-buster AS build_frontend
+
+WORKDIR /app
+COPY . .
+
+COPY --from=fetch_data /app/koroonakaart/src/data.json /app/koroonakaart/src/data.json
+RUN cd koroonakaart \
+    npm install --silent \
+    npm run build
+
+#########################
+# STEP 3 build the image (Nginx serving frontend)
+#########################
+FROM nginx:1.19.2-alpine
+
+COPY --from=build_frontend /app/koroonakaart/dist /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -23,7 +23,23 @@ You can use the export menu on the charts (hamburger menu on the top right), sel
 Accepts height and width currently as props through query string.
 
 ## Project setup
+
+### Get/update data from TEHIK API
+
+Download latest Estonian COVID-19 data from TEHIK and transform it into json format 
+
 ```
+cd TEHIK_Open_Data_Loading_Scripts/
+pip3 install -r requirements.txt
+python3 main.py
+```
+
+### Install frontend dependencies
+
+To Customize Vue.js configuration see [Configuration Reference](https://cli.vuejs.org/config/).
+
+```
+cd koroonakaart/
 npm install
 ```
 
@@ -33,22 +49,25 @@ npm run serve
 ```
 
 ### Compiles and minifies for production
+
 ```
 npm run build
 ```
 
 ### Lints and fixes files
+
 ```
 npm run lint
 ```
-### Get data from TEHIK API
-```
-pip3 install -r requirements.txt
-python3 main.py
-```
 
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+### Building Docker image
+
+```
+docker build -t koroonakaart .
+
+# run container in foreground (open http://localhost:8080)
+docker run --rm -p 8080:80 --name koroona koroonakaart:latest
+```
 
 
 # Who we are?


### PR DESCRIPTION
This pull request adds some automation and deploy support

Added:
1.  Added Github actions support (https://github.com/features/actions). Now deploy artifacts can be built manually by triggering workflow action in Gitub GUI (manually because not to fetch too frequently open data). To run workflow: go to `Actions` and click `Run workflow` button at right side of screen. This will be visible when action is merged to main branch.
    Workflow definition is here: ```.github/workflows/package.yml```

2. Added [Docker](https://www.docker.com/) support to create own images with koroonakaart (nginx is serving frontend)  
    ```
    docker build -t koroonakaart .
    
    # run container in foreground (open http://localhost:8080)
    docker run --rm -p 8080:80 --name koroona koroonakaart:latest
    ```