### PR TITLE
Implement correct thousands and decimal separators

### DIFF
--- a/koroonakaart/src/components/Statsbar.vue
+++ b/koroonakaart/src/components/Statsbar.vue
@@ -194,9 +194,7 @@
         </h1>
         <h5 class="negative">
           (
-          {{
-            completedVaccinationNumberLastDay | formatNumber(currentLocale)
-          }}
+          {{ completedVaccinationNumberLastDay | formatNumber(currentLocale) }}
           )
         </h5>
       </b-col>
@@ -320,11 +318,16 @@ export default {
 
   filters: {
     formatNumber: function (number, currentLocale) {
+      let result = "";
+
       if (typeof number === "string" && number.startsWith("+")) {
         const actualNumber = number.split("+")[1];
-        return "+" + formatNumberByLocale(actualNumber, currentLocale);
+        result = "+" + formatNumberByLocale(actualNumber, currentLocale);
+      } else {
+        result = formatNumberByLocale(number, currentLocale);
       }
-      return formatNumberByLocale(number, currentLocale);
+
+      return result.replace(/\s/g, '\u202F')
     },
   },
 };

--- a/koroonakaart/src/components/Statsbar.vue
+++ b/koroonakaart/src/components/Statsbar.vue
@@ -1,14 +1,14 @@
 <template>
   <b-container id="statsbar-container" class="mb-5" fluid>
     <b-row
-      ><small style="margin-bottom: 20px;">{{ $t("faq.a5") }}</small></b-row
+      ><small style="margin-bottom: 20px">{{ $t("faq.a5") }}</small></b-row
     >
     <b-row>
       <b-col class="statsbar-item" md>
         <div class="statsbar-heading">
           <h5>{{ $t("confirmedCases") }}</h5>
         </div>
-        <h1>{{ confirmedCasesNumber }}</h1>
+        <h1>{{ confirmedCasesNumber | formatNumber(currentLocale) }}</h1>
         <h5
           :class="
             rawConfirmedChanged === 0
@@ -18,7 +18,7 @@
               : 'positive'
           "
         >
-          ( {{ confirmedChanged }} )
+          ( {{ confirmedChanged | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
 
@@ -26,7 +26,7 @@
         <div class="statsbar-heading">
           <h5>{{ $t("activeCases") }}</h5>
         </div>
-        <h1>{{ activeCasesNumber }}</h1>
+        <h1>{{ activeCasesNumber | formatNumber(currentLocale) }}</h1>
         <h5
           :class="
             rawActiveChanged === 0
@@ -44,7 +44,7 @@
         <div class="statsbar-heading">
           <h5>{{ $t("perHundred") }}</h5>
         </div>
-        <h1>{{ perHundred }}</h1>
+        <h1>{{ perHundred | formatNumber(currentLocale) }}</h1>
         <h5
           :class="
             rawPerHundredChanged === 0
@@ -54,7 +54,7 @@
               : 'negative'
           "
         >
-          ( {{ rawPerHundredChanged }} )
+          ( {{ rawPerHundredChanged | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
 
@@ -62,7 +62,7 @@
         <div class="statsbar-heading">
           <h5>{{ $t("testsAdministered") }}</h5>
         </div>
-        <h1>{{ testsAdministeredNumber }}</h1>
+        <h1>{{ testsAdministeredNumber | formatNumber(currentLocale) }}</h1>
         <h5
           :class="
             rawTestsChanged === 0
@@ -72,7 +72,7 @@
               : 'positive'
           "
         >
-          ( {{ testsChanged }} )
+          ( {{ testsChanged | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
     </b-row>
@@ -82,7 +82,7 @@
         <div class="statsbar-heading">
           <h5>{{ $t("hospitalised") }}</h5>
         </div>
-        <h1>{{ hospitalisedNumber }}</h1>
+        <h1>{{ hospitalisedNumber | formatNumber(currentLocale) }}</h1>
         <h5
           :class="
             rawHospitalisedChanged === 0
@@ -92,7 +92,7 @@
               : 'negative'
           "
         >
-          ( {{ hospitalisedChanged }} )
+          ( {{ hospitalisedChanged | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
 
@@ -100,7 +100,7 @@
         <div class="statsbar-heading">
           <h5>{{ $t("recovered") }}</h5>
         </div>
-        <h1>{{ recoveredNumber }}</h1>
+        <h1>{{ recoveredNumber | formatNumber(currentLocale) }}</h1>
         <h5
           :class="
             rawRecoveredChanged === 0
@@ -110,7 +110,7 @@
               : 'positive'
           "
         >
-          ( {{ recoveredChanged }} )
+          ( {{ recoveredChanged | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
 
@@ -128,15 +128,17 @@
               : 'negative'
           "
         >
-          ( {{ deceasedChanged }} )
+          ( {{ deceasedChanged | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
       <b-col class="statsbar-item" md>
         <div class="statsbar-heading">
           <h5>{{ $t("pos14avg") }}</h5>
         </div>
-        <h1>{{ positiveTestAverage14Percent }} %</h1>
-      <!--  <h5
+        <h1>
+          {{ positiveTestAverage14Percent | formatNumber(currentLocale) }} %
+        </h1>
+        <!--  <h5
           :class="
             rawDeceasedChanged === 0
               ? 'neutral'
@@ -155,9 +157,9 @@
         <div class="statsbar-heading">
           <h5>{{ $t("allVaccinated") }}</h5>
         </div>
-        <h1>{{ allVaccinationNumberTotal }}</h1>
-        <h5 class="negative" >
-          ( {{ allVaccinationNumberLastDay }} )
+        <h1>{{ allVaccinationNumberTotal | formatNumber(currentLocale) }}</h1>
+        <h5 class="negative">
+          ( {{ allVaccinationNumberLastDay | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
 
@@ -165,16 +167,21 @@
         <div class="statsbar-heading">
           <h5>{{ $t("allVaccinatedPercentage") }}</h5>
         </div>
-        <h1>{{ allVaccinationFromPopulationPercentage }} %</h1>
+        <h1>
+          {{
+            allVaccinationFromPopulationPercentage | formatNumber(currentLocale)
+          }}
+          %
+        </h1>
       </b-col>
 
       <b-col class="statsbar-item" md>
         <div class="statsbar-heading">
           <h5>{{ $t("vaccinationNumber") }}</h5>
         </div>
-        <h1>{{ vaccinationNumberTotal }}</h1>
-        <h5 class="negative" >
-          ( {{ vaccinationNumberLastDay }} )
+        <h1>{{ vaccinationNumberTotal | formatNumber(currentLocale) }}</h1>
+        <h5 class="negative">
+          ( {{ vaccinationNumberLastDay | formatNumber(currentLocale) }} )
         </h5>
       </b-col>
 
@@ -182,9 +189,15 @@
         <div class="statsbar-heading">
           <h5>{{ $t("completedVaccinationNumber") }}</h5>
         </div>
-        <h1>{{ completedVaccinationNumberTotal }}</h1>
-        <h5 class="negative" >
-          ( {{ completedVaccinationNumberLastDay }} )
+        <h1>
+          {{ completedVaccinationNumberTotal | formatNumber(currentLocale) }}
+        </h1>
+        <h5 class="negative">
+          (
+          {{
+            completedVaccinationNumberLastDay | formatNumber(currentLocale)
+          }}
+          )
         </h5>
       </b-col>
 
@@ -192,9 +205,14 @@
         <div class="statsbar-heading">
           <h5>{{ $t("completelyVaccinatedFromTotalVaccinatedPercentage") }}</h5>
         </div>
-        <h1>{{ completelyVaccinatedFromTotalVaccinatedPercentage }} %</h1>
+        <h1>
+          {{
+            completelyVaccinatedFromTotalVaccinatedPercentage
+              | formatNumber(currentLocale)
+          }}
+          %
+        </h1>
       </b-col>
-
     </b-row>
   </b-container>
 </template>
@@ -202,13 +220,15 @@
 <script>
 import data from "../data.json";
 import { positiveSign } from "../utilities/helper";
+import { formatNumberByLocale } from "../utilities/formatNumberByLocale";
 export default {
   name: "Statsbar",
 
   data() {
     return {
       activeCasesNumber: data.activeCasesNumber,
-      positiveTestAverage14Percent: data.dataTestsPerDayChart.positiveTestAverage14Percent,
+      positiveTestAverage14Percent:
+        data.dataTestsPerDayChart.positiveTestAverage14Percent,
       confirmedCasesNumber: data.confirmedCasesNumber,
       deceasedNumber: data.deceasedNumber,
       perHundred:
@@ -276,14 +296,36 @@ export default {
           ]
       ),
       allVaccinationNumberTotal: data.allVaccinationNumberTotal,
-      allVaccinationNumberLastDay: positiveSign(data.allVaccinationNumberLastDay),
-      allVaccinationFromPopulationPercentage: data.allVaccinationFromPopulationPercentage,
+      allVaccinationNumberLastDay: positiveSign(
+        data.allVaccinationNumberLastDay
+      ),
+      allVaccinationFromPopulationPercentage:
+        data.allVaccinationFromPopulationPercentage,
       vaccinationNumberTotal: data.vaccinationNumberTotal,
       vaccinationNumberLastDay: positiveSign(data.vaccinationNumberLastDay),
       completedVaccinationNumberTotal: data.completedVaccinationNumberTotal,
-      completedVaccinationNumberLastDay: positiveSign(data.completedVaccinationNumberLastDay),
-      completelyVaccinatedFromTotalVaccinatedPercentage: data.completelyVaccinatedFromTotalVaccinatedPercentage,
+      completedVaccinationNumberLastDay: positiveSign(
+        data.completedVaccinationNumberLastDay
+      ),
+      completelyVaccinatedFromTotalVaccinatedPercentage:
+        data.completelyVaccinatedFromTotalVaccinatedPercentage,
     };
+  },
+
+  computed: {
+    currentLocale: function () {
+      return this.$i18n.locale;
+    },
+  },
+
+  filters: {
+    formatNumber: function (number, currentLocale) {
+      if (typeof number === "string" && number.startsWith("+")) {
+        const actualNumber = number.split("+")[1];
+        return "+" + formatNumberByLocale(actualNumber, currentLocale);
+      }
+      return formatNumberByLocale(number, currentLocale);
+    },
   },
 };
 </script>

--- a/koroonakaart/src/utilities/formatNumberByLocale.js
+++ b/koroonakaart/src/utilities/formatNumberByLocale.js
@@ -1,0 +1,5 @@
+export function formatNumberByLocale(num, locale) {
+  if(!num || ! locale) throw new Error('Number or locale is missing')
+  const parsedNumber = typeof num === "string" ? parseFloat(num) : num;
+  return new Intl.NumberFormat(locale).format(parsedNumber);
+}


### PR DESCRIPTION
My apologies, one of the commits has the wrong issue number 😕 .
I just used the browser's [Intl api](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat) to format the numbers instead of hacking html.
<img width="1213" alt="Screenshot 2021-04-10 at 15 48 28" src="https://user-images.githubusercontent.com/3602825/114270322-65a0ea00-9a14-11eb-8ec5-115ce26ded78.png">
<img width="1254" alt="Screenshot 2021-04-10 at 15 48 43" src="https://user-images.githubusercontent.com/3602825/114270325-689bda80-9a14-11eb-866e-b94f13fc0885.png">
<img width="1254" alt="Screenshot 2021-04-10 at 15 48 59" src="https://user-images.githubusercontent.com/3602825/114270327-69cd0780-9a14-11eb-8a09-5d5ec810895c.png">
